### PR TITLE
Use `c_char` instead of `i8` in `supported_func`

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -140,8 +140,8 @@ pub trait UISupport {
 }
 
 unsafe extern "C" fn supported_func<S: UISupport>(
-    container_type_uri: *const i8,
-    ui_type_uri: *const i8,
+    container_type_uri: *const std::os::raw::c_char,
+    ui_type_uri: *const std::os::raw::c_char,
 ) -> u32 {
     S::supported(
         CStr::from_ptr(container_type_uri).to_str().unwrap(),


### PR DESCRIPTION
The parameters of [`lilv_sys::LilvUISupportedFunc`](https://docs.rs/lilv-sys/0.2.1/lilv_sys/type.LilvUISupportedFunc.html) have type `*const c_char`, but `lilv::ui::supported_func` declares them as `*const i8`, which causes compilation errors on platforms like ARM and PowerPC where `c_char` is an alias of `u8`:

```
error[E0308]: mismatched types
   --> /tmp/lilv-rs/src/ui.rs:75:22
    |
75  |                 Some(supported_func::<S>),
    |                 ---- ^^^^^^^^^^^^^^^^^^^ expected fn pointer, found fn item
    |                 |
    |                 arguments to this enum variant are incorrect
    |
    = note: expected fn pointer `unsafe extern "C" fn(*const u8, *const u8) -> _`
                  found fn item `unsafe extern "C" fn(*const i8, *const i8) -> _ {supported_func::<S>}`
```

This PR updates the declaration of `supported_func` to match `LilvUISupportedFunc`.